### PR TITLE
Removed apostrophes from possessive cases of "its"

### DIFF
--- a/book/01-introduction/sections/03-basics.asc
+++ b/book/01-introduction/sections/03-basics.asc
@@ -15,7 +15,7 @@ This is the Atom welcome screen and gives you a pretty good starting point for h
 First of all, let's get acquainted with some of the terminology we'll be using in this manual.
 
 Buffer::
-  A buffer is the text content of a file in Atom. It's basically the same as a file for most descriptions, but it's the version Atom has in memory. For instance, you can change the text of a buffer and it isn't written to it's associated file until you save it.
+  A buffer is the text content of a file in Atom. It's basically the same as a file for most descriptions, but it's the version Atom has in memory. For instance, you can change the text of a buffer and it isn't written to its associated file until you save it.
 
 Pane::
   A pane is a visual section of Atom. If you look at the welcome screen we just launched, you can see four Panes - the tab bar, the gutter (which has line numbers in it), the status bar at the bottom and finally the text editor.
@@ -142,11 +142,11 @@ You can also hide and show it with `cmd-\` or the `tree-view:toggle` command fro
 [NOTE]
 .Atom Modules
 ====
-Like many parts of Atom, the Tree view is not built directly into the editor, but is it's own standalone package that is simply shipped with Atom by default.
+Like many parts of Atom, the Tree view is not built directly into the editor, but is its own standalone package that is simply shipped with Atom by default.
 
 You can find the source code to the Tree view here: https://github.com/atom/tree-view
 
-This is one of the interesting things about Atom. Many of it's core features are actually just packages implemented the same way you would implement any other functionality. This means that if you don't like the Tree view for example, it's fairly simple to write your own implementation of that functionality and replace it entirely.
+This is one of the interesting things about Atom. Many of its core features are actually just packages implemented the same way you would implement any other functionality. This means that if you don't like the Tree view for example, it's fairly simple to write your own implementation of that functionality and replace it entirely.
 ====
 
 ===== Opening a File in a Project


### PR DESCRIPTION
This is my first ever pull request! Today I read the Getting Started part of the manual and got the idea but could not help noticing those stray apostrophes. I figured they might be a good fix to tackle for my first time.